### PR TITLE
Remove facenet.tar.net after extracting it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG model_file=facenet.tar.gz
 RUN apt-get update && apt-get install libgtk2.0 -y
 
 RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v
+RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net
 ARG model_file=facenet.tar.gz
 
 # Add the missing packages for OpenCV
-RUN apt-get update && apt-get install libgtk2.0 -y
+RUN apt-get update && apt-get install libgtk2.0 -y && rm -rf /var/lib/apt/lists/*
 
 RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
 RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}


### PR DESCRIPTION
Thanks for @bdwyer2 's suggestion. This PR removes the file facenet.tar.gz from the assets/ directory after extracting it during the build. It reduces the size of the image by 84 MB.